### PR TITLE
Drop the shutdown JSON API restart and the debug traces

### DIFF
--- a/plugins/FeedReader/FeedReaderPlugin.cpp
+++ b/plugins/FeedReader/FeedReaderPlugin.cpp
@@ -32,6 +32,7 @@
 #include "services/p3FeedReader.h"
 #include "services/FeedReaderJsonApi.h"
 #include <retroshare/rsjsonapi.h>
+#include <util/rsdebug.h>
 
 #include <libxml/xmlversion.h>
 #include <libxslt/xsltconfig.h>
@@ -94,8 +95,6 @@ FeedReaderPlugin::FeedReaderPlugin()
 void FeedReaderPlugin::setInterfaces(RsPlugInInterfaces &interfaces)
 {
 	mInterfaces = interfaces;
-	std::cerr << "FeedReader: JSON API interface pointer="
-	          << static_cast<void*>(mInterfaces.mJsonApi) << std::endl;
 
 	mFeedReader = new p3FeedReader(mPlugInHandler, mInterfaces.mGxsForums, mInterfaces.mPosted);
 	rsFeedReader = mFeedReader;
@@ -107,15 +106,14 @@ void FeedReaderPlugin::setInterfaces(RsPlugInInterfaces &interfaces)
 	{
 		mJsonApiProvider = new FeedReaderJsonApi(*mFeedReader, *mInterfaces.mJsonApi);
 		mInterfaces.mJsonApi->registerResourceProvider(*mJsonApiProvider);
-		std::cerr << "FeedReader: JSON API provider registered="
-		          << mInterfaces.mJsonApi->hasResourceProvider(*mJsonApiProvider)
-		          << std::endl;
-		// The core publishes all providers together after plugin initialization.
-		// This avoids one burst-protected JSON API restart per plugin.
+
+		// No restart here: the core publishes every provider together once all
+		// plugins have received their interfaces, which avoids one
+		// burst-protected JSON API restart per plugin.
+		RsDbg() << "FeedReader: JSON API routes registered.";
 	}
 	else
-		std::cerr << "FeedReader: JSON API unavailable; routes not registered"
-		          << std::endl;
+		RsInfo() << "FeedReader: JSON API not available, routes not registered.";
 }
 
 ConfigPage *FeedReaderPlugin::qt_config_page() const
@@ -145,11 +143,13 @@ void FeedReaderPlugin::stop()
 	if(mJsonApiProvider)
 	{
 		if(mInterfaces.mJsonApi)
-		{
 			mInterfaces.mJsonApi->unregisterResourceProvider(*mJsonApiProvider);
-			if(mInterfaces.mJsonApi->isRunning())
-				mInterfaces.mJsonApi->restart(true);
-		}
+
+		/* No restart here. The core stops the JSON API before it stops the
+		 * plugins, so the restbed resources whose handlers capture this
+		 * provider are already gone by now and deleting it is safe. Restarting
+		 * would only wait out RESTART_BURST_PROTECTION and bring the server
+		 * back up in the middle of the core teardown. */
 		delete mJsonApiProvider;
 		mJsonApiProvider = NULL;
 	}

--- a/plugins/FeedReader/services/FeedReaderJsonApi.cpp
+++ b/plugins/FeedReader/services/FeedReaderJsonApi.cpp
@@ -20,7 +20,6 @@
 
 #include "FeedReaderJsonApi.h"
 
-#include <iostream>
 #include <sstream>
 
 #include <rapidjson/document.h>
@@ -179,7 +178,6 @@ FeedReaderJsonApi::FeedReaderJsonApi(
 
 std::vector<std::shared_ptr<restbed::Resource>> FeedReaderJsonApi::getResources() const
 {
-	std::cerr << "FeedReader: constructing JSON API resources" << std::endl;
 	std::vector<std::shared_ptr<restbed::Resource>> resources;
 	auto resource = [this](const std::string& path, auto handler)
 	{


### PR DESCRIPTION
Follow-up to the review on RetroShare/RetroShare#3289. One commit on top of `819a9b290`.

> [!IMPORTANT]
> Depends on RetroShare/libretroshare#366. Merging this first would turn a slow shutdown into a use-after-free — see below.

### The restart in `stop()`

`FeedReaderPlugin::stop()` unregisters the provider and then restarts the JSON API. That costs a `RESTART_BURST_PROTECTION` wait (7 s) on every exit and brings the HTTP server back up in the middle of the core teardown, republishing resources whose backing services are about to stop.

It was not gratuitous, though, and this is the part worth being careful about: it is what made `delete mJsonApiProvider` safe. `JsonApiServer::run()` publishes the resources this provider returns once at thread start, and the restbed service holds them for its whole lifetime with handlers capturing the provider. Restarting destroys the old service, so by the time the `delete` runs the resources are gone.

Dropping the restart on its own would therefore leave the provider deleted underneath a live server, with a window running from `stopPlugins()` (`p3face-config.cc:104`) to the `fullstop()` at the end of `rsGlobalShutDown()` — tens of seconds, while a web interface polls.

RetroShare/libretroshare#366 fixes the ordering in the core instead, stopping the JSON API at the top of `rsGlobalShutDown()`, before `stopPlugins()`. With that in, the resources are already gone when `stop()` runs, the `delete` is safe, and the plugin does not need to restart a core service to clean up after itself. That is the right place for it: any provider-registering plugin gets the same guarantee for free.

### Debug traces

The five `std::cerr` traces become one `RsDbg` line on success and an `RsInfo` when the JSON API is not available, matching how the rest of the tree reports. The one in `FeedReaderJsonApi::getResources()` fired on every restart.

### Checked and fine, so nobody has to re-check

- **Authentication is correct.** `makeResource()` installs a `set_authentication_handler` that validates the `Authorization` header through `isAuthTokenValid()` and closes with `UNAUTHORIZED` otherwise, `OPTIONS` excepted. `addFeed` — which takes a URL plus user/password — is not open.
- `authenticate()` is equivalent to the core's `decodeToken()`, and safer: it checks `decoded.empty()` first, where the core does `&decodedVect[0]` on a possibly empty vector.
- No credential leak: `feedToJson()` exposes neither `user` nor `password`.
- No update bug: `feedToInfo()` does copy user/password, so the read-modify-write in `updateFeed` preserves authentication.
- The plugin's CORS headers are narrower than the core's, not wider.

Two small things left alone, happy to add either if you want them: the core logs an `RsWarn` on every blocked authenticated call and `/rsFeedReader/*` fails silently, and `authenticate()` does not check `isLoggedIn()` the way the core does — practically unreachable, since providers only exist after login.

Not build-tested, and the Windows side (restbed link, `WIN_DLL_EXPORT`) is untouched here but still wants a build check.